### PR TITLE
Fix help_label of dialog-doclink.glade

### DIFF
--- a/gnucash/gnome/dialog-doclink.c
+++ b/gnucash/gnome/dialog-doclink.c
@@ -988,10 +988,10 @@ gnc_doclink_dialog_create (GtkWindow *parent, DoclinkDialog *doclink_dialog)
     {
         GtkWidget *help_label = GTK_WIDGET(gtk_builder_get_object (builder, "help_label"));
         const gchar *item_string = N_(
-            "\t\tDouble click on the entry in the Id column to jump to the"
-            "Business Item.\n\t\tDouble click on the entry in the Link column"
-            "to open the Linked Document.\n\t\tDouble click on the entry in"
-            "the Available? column to modify the document link.");
+            "\t\tDouble click on the entry in the Id column to jump to the "
+            "Business Item.\n\t\tDouble click on the entry in the Link column "
+            "to open the Linked Document.\n\t\tDouble click on the entry in "
+            "the Available column to modify the document link.");
 
         /* Translators: This is the label of a dialog box that lists all of the
            invoices, bills, and vouchers that have files or URIs linked with

--- a/gnucash/gtkbuilder/dialog-doclink.glade
+++ b/gnucash/gtkbuilder/dialog-doclink.glade
@@ -671,7 +671,7 @@
                 <child>
                   <object class="GtkTreeViewColumn" id="available">
                     <property name="resizable">True</property>
-                    <property name="title" translatable="yes">Available ?</property>
+                    <property name="title" translatable="yes">Available</property>
                     <property name="alignment">0.5</property>
                     <property name="sort_column_id">5</property>
                     <child>
@@ -730,7 +730,9 @@
             <property name="can_focus">False</property>
             <property name="margin_top">3</property>
             <property name="margin_bottom">3</property>
-            <property name="label" translatable="yes">"\t\tDouble click on the entry in the Description column to jump to the Transaction.\n\t\tDouble click on the entry in the Link column to open the Linked Document.\n\t\tDouble click on the entry in the Available? column to modify the document link."</property>
+            <property name="label" translatable="yes">Double click on the entry in the Description column to jump to the Transaction.
+Double click on the entry in the Link column to open the Linked Document.
+Double click on the entry in the Available column to modify the document link.</property>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
XML is different from C format. ;-)

Additonal remove question mark from Available. I see no reason for it.
Fnally insert missing spaces into the Business Item variant.

I wonder, if the text could be more unique. The distinction is already in the dialog title.

Please review the min size. I got 600 instead of your 450 to avoid the h. scrollbar.